### PR TITLE
Fix typo in immutable section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ var Immutable  = require("immutable"),
     comp       = t.comp,
     map        = t.map,
     filter     = t.filter,
-    transduce  = t.transduce,
+    transduce  = t.transduce;
 
 var inc = function(n) { return n + 1; };
 var isEven = function(n) { return n % 2 == 0; };


### PR DESCRIPTION
Fix a small typo that prevents the example from being copy-pasted as-is.