### PR TITLE
Correct documentation for keepIndexed

### DIFF
--- a/src/com/cognitect/transducers.js
+++ b/src/com/cognitect/transducers.js
@@ -788,7 +788,7 @@ goog.scope(function() {
 
     /**
      * Like keep but the provided function will be passed the
-     * index as the second argument.
+     * index as the first argument and the value as the second.
      * @method transducers.keepIndexed
      * @param {Function} f a function
      * @return {com.cognitect.transducers.KeepIndexed} a keepIndexed transducer


### PR DESCRIPTION
As far as I can tell, the function passed to `keepIndex` is called with the index as the first arg, and the value as the second.