### PR TITLE
Fix a typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ iterator is reducible/transducible. An ES6 iterator may also just be given direc
 
 ## Building
 
-Fetch the dependecies:
+Fetch the dependencies:
 
 ```
 bin/deps


### PR DESCRIPTION
`dependecies` → `dependencies`