### PR TITLE
fix keep return result

### DIFF
--- a/src/com/cognitect/transducers.js
+++ b/src/com/cognitect/transducers.js
@@ -736,7 +736,7 @@ goog.scope(function() {
         if(v == null) {
             return result;
         } else {
-            return this.xf["@@transducer/step"](result, input);
+            return this.xf["@@transducer/step"](result, v);
         }
     };
 
@@ -782,7 +782,7 @@ goog.scope(function() {
         if(v == null) {
             return result;
         } else {
-            return this.xf["@@transducer/step"](result, input);
+            return this.xf["@@transducer/step"](result, v);
         }
     };
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -60,7 +60,7 @@ var square = function(n) {
 };
 
 var keepEven = function(n) {
-    return (n % 2 == 0) ? true : null;
+    return (n % 2 == 0) ? n*2 : null;
 };
 
 var keepIdxFn = function(i, x) {
@@ -70,7 +70,7 @@ var keepIdxFn = function(i, x) {
         case 3:
         case 6:
         case 7:
-        return true;
+        return i*2;
         break;
         default:
         return null;
@@ -120,13 +120,13 @@ exports.testRemove = function(test) {
 
 exports.testKeep = function(test) {
     var res = transduce(keep(keepEven), arrayPush, [], smallArray);
-    test.deepEqual(res, smallArray.filter(isEven));
+    test.deepEqual(res, smallArray.filter(isEven).map(function (x) { return x*2; }));
     test.done();
 };
 
 exports.testKeepIndexed = function(test) {
     var res = transduce(keepIndexed(keepIdxFn), arrayPush, [], smallArray);
-    test.deepEqual(res, [0, 2, 3, 6, 7]);
+    test.deepEqual(res, [0, 4, 6, 12, 14]);
     test.done();
 };
 


### PR DESCRIPTION
This changes the behavior of Keep and KeepIndexed to return the result of the provided function per https://github.com/cognitect-labs/transducers-js/issues/31.

This is a breaking change but is consistent with the Clojure implementation.