### PR TITLE
Add ModuleLoader to satisfy new constructor arity

### DIFF
--- a/bin/closure_deps_graph.clj
+++ b/bin/closure_deps_graph.clj
@@ -2,7 +2,7 @@
   (:require [clojure.java.io :as io])
   (:import [java.io File]
            [com.google.javascript.jscomp SourceFile BasicErrorManager]
-           [com.google.javascript.jscomp.deps DepsGenerator DepsGenerator$InclusionStrategy]))
+           [com.google.javascript.jscomp.deps ModuleLoader DepsGenerator DepsGenerator$InclusionStrategy]))
 
 (defn js-files-in
   "Return a sequence of all .js files in the given directory."
@@ -25,4 +25,5 @@
         (report [level error]
           (println error))
         (println [level error]
-          (println error))))))
+          (println error)))
+      ModuleLoader/EMPTY)))


### PR DESCRIPTION
This addresses a breaking change in the closure-compiler library as referenced in https://github.com/cognitect-labs/transducers-js/issues/39